### PR TITLE
Make show/hide links nofollow for google SEO

### DIFF
--- a/adm/style/event/acp_overall_header_body_before.html
+++ b/adm/style/event/acp_overall_header_body_before.html
@@ -1,10 +1,10 @@
 {# This file was generated with the ext-showphpbbevents:generate command. #}
 {%- if marttiphpbb_showphpbbevents.enable -%}
-<a class="showphpbbevents-hide" href="{{- marttiphpbb_showphpbbevents.u_hide -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE_EXPLAIN') -}}">
+<a class="showphpbbevents-hide" href="{{- marttiphpbb_showphpbbevents.u_hide -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE_EXPLAIN') -}}" rel="nofollow">
 	{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE') -}}
 </a>{%- endif -%}
 {%- if not marttiphpbb_showphpbbevents.enable -%}
-<a class="showphpbbevents-show" href="{{- marttiphpbb_showphpbbevents.u_show -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW_EXPLAIN') -}}">
+<a class="showphpbbevents-show" href="{{- marttiphpbb_showphpbbevents.u_show -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW_EXPLAIN') -}}" rel="nofollow">
 	{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW') -}}
 </a>{%- endif -%}
 {%- if marttiphpbb_showphpbbevents.enable -%}

--- a/adm/style/event/acp_simple_header_body_before.html
+++ b/adm/style/event/acp_simple_header_body_before.html
@@ -1,10 +1,10 @@
 {# This file was generated with the ext-showphpbbevents:generate command. #}
 {%- if marttiphpbb_showphpbbevents.enable -%}
-<a class="showphpbbevents-hide" href="{{- marttiphpbb_showphpbbevents.u_hide -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE_EXPLAIN') -}}">
+<a class="showphpbbevents-hide" href="{{- marttiphpbb_showphpbbevents.u_hide -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE_EXPLAIN') -}}" rel="nofollow">
 	{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE') -}}
 </a>{%- endif -%}
 {%- if not marttiphpbb_showphpbbevents.enable -%}
-<a class="showphpbbevents-show" href="{{- marttiphpbb_showphpbbevents.u_show -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW_EXPLAIN') -}}">
+<a class="showphpbbevents-show" href="{{- marttiphpbb_showphpbbevents.u_show -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW_EXPLAIN') -}}" rel="nofollow">
 	{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW') -}}
 </a>{%- endif -%}
 {%- if marttiphpbb_showphpbbevents.enable -%}

--- a/styles/all/template/event/overall_header_body_before.html
+++ b/styles/all/template/event/overall_header_body_before.html
@@ -1,10 +1,10 @@
 {# This file was generated with the ext-showphpbbevents:generate command. #}
 {%- if marttiphpbb_showphpbbevents.enable -%}
-<a class="showphpbbevents-hide" href="{{- marttiphpbb_showphpbbevents.u_hide -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE_EXPLAIN') -}}">
+<a class="showphpbbevents-hide" href="{{- marttiphpbb_showphpbbevents.u_hide -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE_EXPLAIN') -}}" rel="nofollow">
 	{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE') -}}
 </a>{%- endif -%}
 {%- if not marttiphpbb_showphpbbevents.enable -%}
-<a class="showphpbbevents-show" href="{{- marttiphpbb_showphpbbevents.u_show -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW_EXPLAIN') -}}">
+<a class="showphpbbevents-show" href="{{- marttiphpbb_showphpbbevents.u_show -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW_EXPLAIN') -}}" rel="nofollow">
 	{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW') -}}
 </a>{%- endif -%}
 {%- if marttiphpbb_showphpbbevents.enable -%}

--- a/styles/all/template/event/simple_header_body_before.html
+++ b/styles/all/template/event/simple_header_body_before.html
@@ -1,10 +1,10 @@
 {# This file was generated with the ext-showphpbbevents:generate command. #}
 {%- if marttiphpbb_showphpbbevents.enable -%}
-<a class="showphpbbevents-hide" href="{{- marttiphpbb_showphpbbevents.u_hide -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE_EXPLAIN') -}}">
+<a class="showphpbbevents-hide" href="{{- marttiphpbb_showphpbbevents.u_hide -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE_EXPLAIN') -}}" rel="nofollow">
 	{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_HIDE') -}}
 </a>{%- endif -%}
 {%- if not marttiphpbb_showphpbbevents.enable -%}
-<a class="showphpbbevents-show" href="{{- marttiphpbb_showphpbbevents.u_show -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW_EXPLAIN') -}}">
+<a class="showphpbbevents-show" href="{{- marttiphpbb_showphpbbevents.u_show -}}" title="{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW_EXPLAIN') -}}" rel="nofollow">
 	{{- lang('MARTTIPHPBB_SHOWPHPBBEVENTS_SHOW') -}}
 </a>{%- endif -%}
 {%- if marttiphpbb_showphpbbevents.enable -%}


### PR DESCRIPTION
As you can see in this link:

https://www.google.com/search?q=viewtopic_modify_post_list_sql&ei=kJ80XKztF-Sh_Qar-rS4DQ&start=60&sa=N&filter=0&ved=0ahUKEwis9YO-n97fAhXkUN8KHSs9Ddc4MhDw0wMIlQE&biw=1696&bih=763

it seems that google picks up on the show link and crawls that page, adding an ugly page to the sites search results.

If site owners leave it on while the crawler happens to be on the site, these will show up... there's no need for that.

I also edited the acp files and hide links for good measure.